### PR TITLE
Expand user file path

### DIFF
--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -19,8 +19,8 @@ def main():
         jot_path = json.loads(config_path.read_text())["JOT_PATH"]
     else:
         # Receive user input
-        jot_path_user = input("Full text file path: ")
-        jot_path = Path(jot_path_user)
+        jot_path_user = input("Path to text file: ")
+        jot_path = Path(jot_path_user).expanduser()
         jot_path.touch()
         # Write to config
         config_file = open(config_path, mode = "w")


### PR DESCRIPTION
Close #6.

Tested on macOS like:

```bash
% jot test
Path to text file: ~/Desktop/jot.txt
Config file written to /Users/mattdray/.jot-config.json
Text file path set to /Users/mattdray/Desktop/jot.txt
Wrote "test" to /Users/mattdray/Desktop/jot.txt
```

Note the supplied path contains a tilde, which is expanded in the printout.