### PR TITLE
Bump v0.2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Each jotting is prepended to the text file in the form `[2025-08-25 11:15] ate a
 Other options are to use the:
 
 * `--help` or `-h` flags for documentation, like `jot -h`
+* `--version` or `-v` flags for the version number, like `jot -v`
 * `--list` or `-l` flags to show the last _n_ jottings, like `jot -l 5`
 * `--search` or `-s` flags to search your jottings for a given term, like `jot -s "apple"` or with a regular expression like `jot -s "2025-08-2([5-9]).*apple"`
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.3"
+version = "0.2.4"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.9"
 
 [[package]]
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.3"
+version = "0.2.4"
 source = { editable = "." }
 dependencies = [
     { name = "argparse" },


### PR DESCRIPTION
Close #27.

* Update `pyproject.toml` and re-lock.
* Update README with `-v` flag.