### PR TITLE
Give default to `--list` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,21 @@ Open a terminal and write a jotting:
 jot "ate an apple"
 ```
 
-The first time you run `jot`, you'll be prompted for a path to a text file where your jottings will be written. The (resolved, absolute and POSIX-standardised) file path will be stored under the `JOT_PATH` key in a `jot_config.json` file saved to your computer's home folder.
+The first time you run `jot`, you'll be prompted for a path to a text file where your jottings will be written. The file path will be stored under the `JOT_PATH` key in a `jot_config.json` file saved to your computer's home folder.
 
 Each jotting is prepended to the text file in the form `[2025-08-25 11:15] ate an apple`.
 
 ### Options
 
-Other options are to use the:
+Append flags to your `jot` call:
 
-* `--help` or `-h` flags for documentation, like `jot -h`
-* `--version` or `-v` flags for the version number, like `jot -v`
-* `--list` or `-l` flags to show the last _n_ jottings, like `jot -l 5`
-* `--search` or `-s` flags to search your jottings for a given term, like `jot -s "apple"` or with a regular expression like `jot -s "2025-08-2([5-9]).*apple"`
+* `-h`/`--help` for help
+* `-v`/`--version` for the version number
+* `-l`/`--list` to show the last _n_ jottings, like `jot -l 7` (defaults to 10 if no value is provided)
+* `-s`/`--search` to search your jottings for a given term, like `jot -s "apple"` or with a regular expression like `jot -s "2025-08-2([5-9]).*apple"`
 
 ## Notes
 
-* Developed to help me remember the tasks I've done during my day job.
+* I developed this to help me remember the tasks I've done during my day job and later reflect.
 * Your kilometerage may vary; [leave an issue](https://github.com/matt-dray/jot/issues) if you find bugs or have suggestions.
 * [v0.1.0](https://github.com/matt-dray/jot/releases/tag/v0.1.0) developed via LLM, [v0.2.0](https://github.com/matt-dray/jot/compare/v0.1.0...v0.2.0) rewritten with my brain (you can [read about it](https://www.rostrum.blog/posts/2025-08-25-jot/)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.4"
+version = "0.2.5"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -58,11 +58,14 @@ def list_jottings(jot_path, n=None):
         print("No jottings yet. Try 'jot hello'.")
         return
 
-    lines = jot_path.read_text().splitlines()
-    if n:
-        lines = lines[:n]
+    lines = jot_path.read_text(encoding="utf-8").splitlines()
 
-    for line in lines:
+    if n is None:
+        lines_to_show = lines  # show all if None
+    else:
+        lines_to_show = lines[:n]
+
+    for line in lines_to_show:
         print(line)
 
 
@@ -84,7 +87,7 @@ def main():
     parser = argparse.ArgumentParser(
         prog="jot",
         description="Minimal opinionated Python CLI to jot timestamped thoughts.",
-        epilog="Source: https://github.com/matt-dray/jot",
+        epilog=f"Source: https://github.com/matt-dray/jot (v{version('jot')})",
     )
     parser.add_argument(
         "text",
@@ -94,7 +97,13 @@ def main():
     )
     parser.add_argument("-v", "--version", action="version", version=version("jot"))
     parser.add_argument(
-        "-l", "--list", nargs="?", type=int, const=0, help="show last n jottings"
+        "-l",
+        "--list",
+        nargs="?",
+        type=int,
+        const=10,
+        default=None,
+        help="show last n jottings (default 10)",
     )
     parser.add_argument(
         "-s",
@@ -114,8 +123,7 @@ def main():
         write_to_config(config_path, jot_path)
 
     if args.list is not None:
-        n = None if args.list == 0 else args.list
-        list_jottings(jot_path, n)
+        list_jottings(jot_path, args.list)
     elif args.search:
         search_jottings(jot_path, args.search)
     elif args.text:

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.9"
 
 [[package]]
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.4"
+version = "0.2.5"
 source = { editable = "." }
 dependencies = [
     { name = "argparse" },


### PR DESCRIPTION
Close #22.

* Limited `-l`/`--list` to show 10 jottings by default if left empty.
* Updated README to reflect the new default.
* Bumped to v0.2.5.