### PR TITLE
Limit returns when searching

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# jot
+# jot <a href="https://www.github.com/matt-dray/jot"><img src='https://www.rostrum.blog/posts/2025-08-30-jot-options/resources/jot.png' height='200px' align='right' alt='Terribly drawn image of the word "jot" in cursive with a pencil at the end of the letter "t". The dot of the letter "i" is a red love heart.'></a>
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Blog
@@ -6,7 +6,7 @@ posts](https://img.shields.io/badge/rostrum.blog-posts-008900?labelColor=000000&
 
 Minimal opinionated Python CLI to jot timestamped thoughts.
 
-<img src='https://www.rostrum.blog/posts/2025-08-30-jot-options/resources/jot.png' width='300px' alt='Terribly drawn image of the word "jot" in cursive with a pencil at the end of the letter "t". The dot of the letter "i" is a red love heart.'>
+
 
 ## Install
 
@@ -31,12 +31,14 @@ Each jotting is prepended to the text file in the form `[2025-08-25 11:15] ate a
 
 ### Options
 
-Append flags to your `jot` call:
+You can append optional flags. For example:
 
-* `-h`/`--help` for help
-* `-v`/`--version` for the version number
-* `-l`/`--list` to show the last _n_ jottings, like `jot -l 7` (defaults to 10 if no value is provided)
-* `-s`/`--search` to search your jottings for a given term, like `jot -s "apple"` or with a regular expression like `jot -s "2025-08-2([5-9]).*apple"`
+* `jot -l 5` to show the last 5 jottings
+* `jot -s apple` to search for 'apple' in jottings
+* `jot -s apple -l 3` to search for 'apple' _and_ limit to 3 jottings
+* `jot -s "2025-08-2([5-9]).*apple"` to search with regex for 'apple' in a given work week
+* `jot -v` to get the version number
+* `jot -h` to show the help file
 
 ## Notes
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# jot <a href="https://www.github.com/matt-dray/jot"><img src='https://www.rostrum.blog/posts/2025-08-30-jot-options/resources/jot.png' height='200px' align='right' alt='Terribly drawn image of the word "jot" in cursive with a pencil at the end of the letter "t". The dot of the letter "i" is a red love heart.'></a>
+# jot <a href="https://www.github.com/matt-dray/jot"><img src='https://www.rostrum.blog/posts/2025-08-30-jot-options/resources/jot.png' height='150px' align='right' alt='Terribly drawn image of the word "jot" in cursive with a pencil at the end of the letter "t". The dot of the letter "i" is a red love heart.'></a>
 
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
 [![Blog
 posts](https://img.shields.io/badge/rostrum.blog-posts-008900?labelColor=000000&logo=data%3Aimage%2Fgif%3Bbase64%2CR0lGODlhEAAQAPEAAAAAABWCBAAAAAAAACH5BAlkAAIAIf8LTkVUU0NBUEUyLjADAQAAACwAAAAAEAAQAAAC55QkISIiEoQQQgghRBBCiCAIgiAIgiAIQiAIgSAIgiAIQiAIgRAEQiAQBAQCgUAQEAQEgYAgIAgIBAKBQBAQCAKBQEAgCAgEAoFAIAgEBAKBIBAQCAQCgUAgEAgCgUBAICAgICAgIBAgEBAgEBAgEBAgECAgICAgECAQIBAQIBAgECAgICAgICAgECAQECAQICAgICAgICAgEBAgEBAgEBAgICAgICAgECAQIBAQIBAgECAgICAgIBAgECAQECAQIBAgICAgIBAgIBAgEBAgECAgECAgICAgICAgECAgECAgQIAAAQIKAAAh%2BQQJZAACACwAAAAAEAAQAAAC55QkIiESIoQQQgghhAhCBCEIgiAIgiAIQiAIgSAIgiAIQiAIgRAEQiAQBAQCgUAQEAQEgYAgIAgIBAKBQBAQCAKBQEAgCAgEAoFAIAgEBAKBIBAQCAQCgUAgEAgCgUBAICAgICAgIBAgEBAgEBAgEBAgECAgICAgECAQIBAQIBAgECAgICAgICAgECAQECAQICAgICAgICAgEBAgEBAgEBAgICAgICAgECAQIBAQIBAgECAgICAgIBAgECAQECAQIBAgICAgIBAgIBAgEBAgECAgECAgICAgICAgECAgECAgQIAAAQIKAAA7)](https://www.rostrum.blog/index.html#category=jot)
 
 Minimal opinionated Python CLI to jot timestamped thoughts.
-
-
 
 ## Install
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.5"
+version = "0.2.6"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -91,7 +91,15 @@ def main():
     parser = argparse.ArgumentParser(
         prog="jot",
         description="Minimal opinionated Python CLI to jot timestamped thoughts.",
-        epilog=f"Source: https://github.com/matt-dray/jot (v{version('jot')})",
+        epilog=(
+            "examples:\n"
+            "  jot 'ate an apple'    add a new jot\n"
+            "  jot -l 5              show last 5 jottings\n"
+            "  jot -s apple          search for 'apple' in jottings\n"
+            "  jot -s apple -l 3     search for 'apple' and limit to last 3 jottings\n"
+            f"\nsource: https://github.com/matt-dray/jot (v{version('jot')})"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "text",
@@ -107,14 +115,16 @@ def main():
         type=int,
         const=10,
         default=None,
-        help="show last n jottings (default 10)",
+        help="show last n jottings (default 10 if no number), "
+        "combine with --search to limit results",
     )
     parser.add_argument(
         "-s",
         "--search",
         nargs="?",
         type=str,
-        help="search jottings (regex supported)",
+        help="search jottings (regex supported), "
+        "combine with --list to limit results",
     )
     args = parser.parse_args()
 

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -58,10 +58,10 @@ def list_jottings(jot_path, n=None):
         print("No jottings yet. Try 'jot hello'.")
         return
 
-    lines = jot_path.read_text(encoding="utf-8").splitlines()
+    lines = jot_path.read_text().splitlines()
 
     if n is None:
-        lines_to_show = lines  # show all if None
+        lines_to_show = lines
     else:
         lines_to_show = lines[:n]
 
@@ -69,7 +69,7 @@ def list_jottings(jot_path, n=None):
         print(line)
 
 
-def search_jottings(jot_path, search_term):
+def search_jottings(jot_path, search_term, limit=None):
     """Search for a term in your jottings (regular expressions supported)."""
     if not jot_path.exists():
         print("No jottings yet. Try 'jot hello'.")
@@ -77,7 +77,11 @@ def search_jottings(jot_path, search_term):
 
     with open(jot_path) as f:
         lines = [line.rstrip("\n") for line in f]
-    matches = list(filter(lambda x: re.search(search_term, x), lines))
+    matches = [line for line in lines if re.search(search_term, line)]
+
+    if limit is not None:
+        matches = matches[:limit]
+
     for line in matches:
         print(line)
 
@@ -122,10 +126,10 @@ def main():
         jot_path = generate_jot()
         write_to_config(config_path, jot_path)
 
-    if args.list is not None:
+    if args.search:
+        search_jottings(jot_path, args.search, args.list)
+    elif args.list is not None:
         list_jottings(jot_path, args.list)
-    elif args.search:
-        search_jottings(jot_path, args.search)
     elif args.text:
         write_jotting(jot_path, args)
     else:

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -75,7 +75,7 @@ def search_jottings(jot_path, search_term, limit=None):
         print("No jottings yet. Try 'jot hello'.")
         return
 
-    with open(jot_path, encoding="utf-8") as f:
+    with jot_path.open("r", encoding="utf-8") as f:
         lines = [line.rstrip("\n") for line in f]
     matches = [line for line in lines if re.search(search_term, line)]
 

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -24,7 +24,7 @@ def get_jot_path(config_path):
 def write_to_config(config_path, jot_path):
     """Write the jot file path to the config file."""
     json_dict = {"JOT_PATH": jot_path.as_posix()}
-    with config_path.open("w") as f:
+    with config_path.open("w", encoding="utf-8") as f:
         json.dump(json_dict, f)
     print(f"Config file written to {config_path}")
     print(f"Text file path set to {jot_path}")
@@ -35,11 +35,11 @@ def write_jotting(jot_path, args):
 
     jot_file_content = ""
     if jot_path.exists():
-        with jot_path.open("r") as f:
+        with jot_path.open("r", encoding="utf-8") as f:
             jot_file_content = f.read()
 
     timestamp = dt.datetime.now().strftime("[%Y-%m-%d %H:%M]")
-    with jot_path.open("w") as f:
+    with jot_path.open("w", encoding="utf-8") as f:
         f.write(f"{timestamp} {args.text}\n{jot_file_content}")
     print(f'Wrote "{args.text}" to {jot_path}')
 
@@ -75,7 +75,7 @@ def search_jottings(jot_path, search_term, limit=None):
         print("No jottings yet. Try 'jot hello'.")
         return
 
-    with open(jot_path) as f:
+    with open(jot_path, encoding="utf-8") as f:
         lines = [line.rstrip("\n") for line in f]
     matches = [line for line in lines if re.search(search_term, line)]
 

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -39,8 +39,9 @@ def write_jotting(jot_path, args):
             jot_file_content = f.read()
 
     timestamp = dt.datetime.now().strftime("[%Y-%m-%d %H:%M]")
-    with jot_path.open("w", encoding="utf-8") as f:
-        f.write(f"{timestamp} {args.text}\n{jot_file_content}")
+    jot_path.write_text(
+        f"{timestamp} {args.text}\n{jot_file_content}", encoding="utf-8"
+    )
     print(f'Wrote "{args.text}" to {jot_path}')
 
 

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -93,7 +93,7 @@ def main():
         description="Minimal opinionated Python CLI to jot timestamped thoughts.",
         epilog=(
             "examples:\n"
-            "  jot 'ate an apple'    add a new jot\n"
+            "  jot 'ate an apple'    add a new jotting\n"
             "  jot -l 5              show last 5 jottings\n"
             "  jot -s apple          search for 'apple' in jottings\n"
             "  jot -s apple -l 3     search for 'apple' and limit to last 3 jottings\n"

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.5"
+version = "0.2.6"
 source = { editable = "." }
 dependencies = [
     { name = "argparse" },


### PR DESCRIPTION
Close #22.

* Allow `--list` to limit returns from `--search`.
* Improve CLI help file.
* Be more consistent in reading/writing.
* Tweak README, use better examples.