### PR TITLE
Add type hints and improve docstrings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.6.9000"
+version = "0.2.6.9001"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -15,7 +15,7 @@ from jot.core import (
 )
 
 
-def main():
+def main() -> None:
     """CLI entry point for jot."""
     parser = argparse.ArgumentParser(
         prog="jot",

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -16,7 +16,12 @@ from jot.core import (
 
 
 def main() -> None:
-    """CLI entry point for jot."""
+    """
+    CLI entry point for jot.
+
+    Returns:
+        None: Performs action depending on user input.
+    """
     parser = argparse.ArgumentParser(
         prog="jot",
         description="Minimal opinionated Python CLI to jot timestamped thoughts.",

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -2,19 +2,20 @@
 Read, write, and return content for config and jot files.
 """
 
+import argparse
 import datetime as dt
 import json
 from pathlib import Path
 import re
 
 
-def build_config_path(json_path=".jot-config.json"):
+def build_config_path(json_path: Path = ".jot-config.json") -> Path:
     """Return the path to the config file in the user's home directory."""
     config_path = Path.home() / json_path
     return config_path
 
 
-def get_jot_path(config_path):
+def get_jot_path(config_path: Path) -> Path:
     """Load the jot file path from the config file."""
     config_text = config_path.read_text()
     config_json = json.loads(config_text)
@@ -23,7 +24,7 @@ def get_jot_path(config_path):
     return jot_path
 
 
-def write_to_config(config_path, jot_path):
+def write_to_config(config_path: Path, jot_path: Path) -> None:
     """Write the jot file path to the config file."""
     json_dict = {"JOT_PATH": jot_path.as_posix()}
     with config_path.open("w", encoding="utf-8") as f:
@@ -32,7 +33,7 @@ def write_to_config(config_path, jot_path):
     print(f"Text file path set to {jot_path}")
 
 
-def write_jotting(jot_path, args):
+def write_jotting(jot_path: Path, args=argparse.Namespace) -> None:
     """Prepend a new jotting with a timestamp to the jot file."""
 
     jot_file_content = ""
@@ -47,7 +48,7 @@ def write_jotting(jot_path, args):
     print(f'Wrote "{args.text}" to {jot_path}')
 
 
-def generate_jot():
+def generate_jot() -> Path:
     """Prompt the user for a jot file path and create it."""
     jot_path_user = input("Path to text file: ")
     jot_path = Path(jot_path_user).expanduser().resolve()
@@ -55,7 +56,7 @@ def generate_jot():
     return jot_path
 
 
-def list_jottings(jot_path, n=None):
+def list_jottings(jot_path: Path, n: int = None) -> None:
     """Print the last n jottings from the jot file."""
     if not jot_path.exists():
         print("No jottings yet. Try 'jot hello'.")
@@ -72,7 +73,7 @@ def list_jottings(jot_path, n=None):
         print(line)
 
 
-def search_jottings(jot_path, search_term, limit=None):
+def search_jottings(jot_path: Path, search_term: str, limit: int = None) -> None:
     """Search for a term in your jottings (regular expressions supported)."""
     if not jot_path.exists():
         print("No jottings yet. Try 'jot hello'.")

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -9,14 +9,30 @@ from pathlib import Path
 import re
 
 
-def build_config_path(json_path: Path = ".jot-config.json") -> Path:
-    """Return the path to the config file in the user's home directory."""
-    config_path = Path.home() / json_path
+def build_config_path(config_file: Path = ".jot-config.json") -> Path:
+    """
+    Build the path to the config file in the user's home directory.
+
+    Args:
+        config_file (Path): The file name for the config file.
+
+    Returns:
+        Path: The file path to the config file.
+    """
+    config_path = Path.home() / config_file
     return config_path
 
 
 def get_jot_path(config_path: Path) -> Path:
-    """Load the jot file path from the config file."""
+    """
+    Read the jot file path from the config file.
+
+    Args:
+        config_path (Path): The path to the config file.
+
+    Returns:
+        Path: The file path to the jot file.
+    """
     config_text = config_path.read_text()
     config_json = json.loads(config_text)
     jot_path_text = config_json["JOT_PATH"]
@@ -25,7 +41,16 @@ def get_jot_path(config_path: Path) -> Path:
 
 
 def write_to_config(config_path: Path, jot_path: Path) -> None:
-    """Write the jot file path to the config file."""
+    """
+    Write the jot file path to the config file.
+
+    Args:
+        config_path (Path): The path to the config file.
+        jot_path (Path): The path to the jot file.
+
+    Returns:
+        None: Prints output.
+    """
     json_dict = {"JOT_PATH": jot_path.as_posix()}
     with config_path.open("w", encoding="utf-8") as f:
         json.dump(json_dict, f)
@@ -34,7 +59,16 @@ def write_to_config(config_path: Path, jot_path: Path) -> None:
 
 
 def write_jotting(jot_path: Path, args=argparse.Namespace) -> None:
-    """Prepend a new jotting with a timestamp to the jot file."""
+    """
+    Prepend a new jotting with a timestamp to the jot file.
+
+    Args:
+        jot_path (Path): The path to the jot file.
+        args (argparse.Namespace): Arguments collected from the argument parser.
+
+    Returns:
+        None: Prints output.
+    """
 
     jot_file_content = ""
     if jot_path.exists():
@@ -49,32 +83,56 @@ def write_jotting(jot_path: Path, args=argparse.Namespace) -> None:
 
 
 def generate_jot() -> Path:
-    """Prompt the user for a jot file path and create it."""
+    """
+    Prompt the user for a jot file path and create it
+
+    Returns:
+        Path: The file path to the jot file.
+    """
     jot_path_user = input("Path to text file: ")
     jot_path = Path(jot_path_user).expanduser().resolve()
     jot_path.touch()
     return jot_path
 
 
-def list_jottings(jot_path: Path, n: int = None) -> None:
-    """Print the last n jottings from the jot file."""
+def list_jottings(jot_path: Path, limit: int = None) -> None:
+    """
+    Print the last n jottings from the jot file.
+
+    Args:
+        jot_path (Path): The path to the jot file.
+        limit (int): Maximum number of recent jottings to print.
+
+    Returns:
+        None: Prints output.
+    """
     if not jot_path.exists():
         print("No jottings yet. Try 'jot hello'.")
         return
 
     lines = jot_path.read_text().splitlines()
 
-    if n is None:
+    if limit is None:
         lines_to_show = lines
     else:
-        lines_to_show = lines[:n]
+        lines_to_show = lines[:limit]
 
     for line in lines_to_show:
         print(line)
 
 
 def search_jottings(jot_path: Path, search_term: str, limit: int = None) -> None:
-    """Search for a term in your jottings (regular expressions supported)."""
+    """
+    Search for a term in your jottings (regular expressions supported).
+
+    Args:
+        jot_path (Path): The path to the jot file.
+        search_term (str): Text string to search (regular expressions supported).
+        limit (int): Maximum number of recent jottings to print.
+
+    Returns:
+        None: Prints output.
+    """
     if not jot_path.exists():
         print("No jottings yet. Try 'jot hello'.")
         return

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.6.9000"
+version = "0.2.6.9001"
 source = { editable = "." }
 dependencies = [
     { name = "argparse" },


### PR DESCRIPTION
Close #33, close #38.

* Add type hints to all functions.
* Expand docstrings to include information about arguments and returns.
* Change argument to `config_file` from `json_path` in `build_config_path()`.
* Bump to dev v0.2.6.9001.