### PR TITLE
Update function names

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ jot is CLI-first, but you can also import its functions to a Python session. For
 ```python
 from jot import *
 config_path = get_config_path()
-jot_path = get_jot_path(config_path)
+jot_path = read_jot_path(config_path)
 search_jottings(jot_path, "apple")
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jot is CLI-first, but you can also import its functions to a Python session. For
 
 ```python
 from jot import *
-config_path = build_config_path()
+config_path = get_config_path()
 jot_path = get_jot_path(config_path)
 search_jottings(jot_path, "apple")
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.6.9001"
+version = "0.2.7"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -5,8 +5,8 @@ Minimal opinionated Python CLI to jot timestamped thoughts.
 from .core import (
     generate_jot,
     get_config_path,
-    get_jot_path,
     list_jottings,
+    read_jot_path,
     search_jottings,
     write_to_config,
     write_jotting,
@@ -15,8 +15,8 @@ from .core import (
 __all__ = [
     "generate_jot",
     "get_config_path",
-    "get_jot_path",
     "list_jottings",
+    "read_jot_path",
     "search_jottings",
     "write_to_config",
     "write_jotting",

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -3,7 +3,7 @@ Minimal opinionated Python CLI to jot timestamped thoughts.
 """
 
 from .core import (
-    generate_jot,
+    create_jot_file,
     get_config_path,
     list_jottings,
     read_jot_path,
@@ -13,7 +13,7 @@ from .core import (
 )
 
 __all__ = [
-    "generate_jot",
+    "create_jot_file",
     "get_config_path",
     "list_jottings",
     "read_jot_path",

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -3,8 +3,8 @@ Minimal opinionated Python CLI to jot timestamped thoughts.
 """
 
 from .core import (
-    build_config_path,
     generate_jot,
+    get_config_path,
     get_jot_path,
     list_jottings,
     search_jottings,
@@ -13,8 +13,8 @@ from .core import (
 )
 
 __all__ = [
-    "build_config_path",
     "generate_jot",
+    "get_config_path",
     "get_jot_path",
     "list_jottings",
     "search_jottings",

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -5,8 +5,8 @@ CLI entry with argument parser.
 import argparse
 from importlib.metadata import version
 from jot.core import (
-    build_config_path,
     generate_jot,
+    get_config_path,
     get_jot_path,
     list_jottings,
     search_jottings,
@@ -62,7 +62,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    config_path = build_config_path()
+    config_path = get_config_path()
 
     if config_path.exists():
         jot_path = get_jot_path(config_path)

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -7,8 +7,8 @@ from importlib.metadata import version
 from jot.core import (
     generate_jot,
     get_config_path,
-    get_jot_path,
     list_jottings,
+    read_jot_path,
     search_jottings,
     write_to_config,
     write_jotting,
@@ -65,7 +65,7 @@ def main() -> None:
     config_path = get_config_path()
 
     if config_path.exists():
-        jot_path = get_jot_path(config_path)
+        jot_path = read_jot_path(config_path)
     else:
         jot_path = generate_jot()
         write_to_config(config_path, jot_path)

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -5,7 +5,7 @@ CLI entry with argument parser.
 import argparse
 from importlib.metadata import version
 from jot.core import (
-    generate_jot,
+    create_jot_file,
     get_config_path,
     list_jottings,
     read_jot_path,
@@ -67,7 +67,7 @@ def main() -> None:
     if config_path.exists():
         jot_path = read_jot_path(config_path)
     else:
-        jot_path = generate_jot()
+        jot_path = create_jot_file()
         write_to_config(config_path, jot_path)
 
     if args.search:

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import re
 
 
-def build_config_path(config_file: Path = ".jot-config.json") -> Path:
+def get_config_path(config_file: Path = ".jot-config.json") -> Path:
     """
     Build the path to the config file in the user's home directory.
 
@@ -149,7 +149,7 @@ def search_jottings(jot_path: Path, search_term: str, limit: int = None) -> None
 
 
 __all__ = [
-    "build_config_path",
+    "get_config_path",
     "generate_jot",
     "get_jot_path",
     "list_jottings",

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -23,7 +23,7 @@ def get_config_path(config_file: Path = ".jot-config.json") -> Path:
     return config_path
 
 
-def get_jot_path(config_path: Path) -> Path:
+def read_jot_path(config_path: Path) -> Path:
     """
     Read the jot file path from the config file.
 
@@ -151,8 +151,8 @@ def search_jottings(jot_path: Path, search_term: str, limit: int = None) -> None
 __all__ = [
     "get_config_path",
     "generate_jot",
-    "get_jot_path",
     "list_jottings",
+    "read_jot_path",
     "search_jottings",
     "write_to_config",
     "write_jotting",

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -82,7 +82,7 @@ def write_jotting(jot_path: Path, args=argparse.Namespace) -> None:
     print(f'Wrote "{args.text}" to {jot_path}')
 
 
-def generate_jot() -> Path:
+def create_jot_file() -> Path:
     """
     Prompt the user for a jot file path and create it
 
@@ -149,8 +149,8 @@ def search_jottings(jot_path: Path, search_term: str, limit: int = None) -> None
 
 
 __all__ = [
+    "create_jot_file",
     "get_config_path",
-    "generate_jot",
     "list_jottings",
     "read_jot_path",
     "search_jottings",

--- a/uv.lock
+++ b/uv.lock
@@ -26,7 +26,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.6.9001"
+version = "0.2.7"
 source = { editable = "." }
 dependencies = [
     { name = "argparse" },


### PR DESCRIPTION
Close #40.

* Rename:
  * `build_config_path()` to `get_config_path()`
  * `get_jot_path()` to `read_jot_path()`
  * `generate_jot()` to `create_jot_file()`
* Bump to v0.2.7 release version.