### PR TITLE
Add options to list jottings between given dates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "argparse>=1.4.0",
     "datetime>=5.5",
     "pathlib>=1.0.1",
+    "python-dateutil>=2.9.0",
     "rich>=14.1.0",
 ]
 

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -3,6 +3,7 @@ CLI entry with argument parser.
 """
 
 import argparse
+from dateutil.parser import parse as date_time
 from importlib.metadata import version
 from jot.core import (
     create_jot_file,
@@ -51,14 +52,31 @@ def main() -> None:
         const=10,
         default=None,
         help="show last n jottings (default 10 if no number), "
-        "combine with --search to limit results",
+        "combine with --search, --from-date, --to-date to limit results",
     )
     parser.add_argument(
         "-s",
         "--search",
         nargs="?",
         type=str,
-        help="search jottings (regex supported), combine with --list to limit results",
+        help="search jottings (regex supported), combine with "
+        "--list, --from-date, --to-date to limit results",
+    )
+    parser.add_argument(
+        "-f",
+        "--from-date",
+        type=date_time,
+        default=None,
+        help="list jottings starting from this date, combine with "
+        "--list or --search to limit results",
+    )
+    parser.add_argument(
+        "-t",
+        "--to-date",
+        type=date_time,
+        default=None,
+        help="list jottings before this date, combine with "
+        "--list or --search to limit results",
     )
     parser.add_argument(
         "-w",
@@ -79,9 +97,11 @@ def main() -> None:
     if args.where:
         print_paths()
     elif args.search:
-        search_jottings(jot_path, args.search, args.list)
+        search_jottings(jot_path, args.search, args.list, args.from_date, args.to_date)
     elif args.list is not None:
-        list_jottings(jot_path, args.list)
+        list_jottings(jot_path, args.list, args.from_date, args.to_date)
+    elif args.from_date is not None or args.to_date is not None:
+        list_jottings(jot_path, None, args.from_date, args.to_date)
     elif args.text:
         write_jotting(jot_path, args)
     else:

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -100,13 +100,35 @@ def create_jot_file() -> Path:
     return jot_path
 
 
-def list_jottings(jot_path: Path, limit: int | None = None) -> None:
+def check_in_period(line: str, period_from: dt.datetime | None, period_to: dt.datetime | None) -> bool:
+    if not line.startswith("[") or "]" not in line:
+        return False
+    stamp = line[1 : line.index("]")]
+    try:
+        date = dt.datetime.strptime(stamp, "%Y-%m-%d %H:%M")
+    except ValueError:
+        return False
+    if period_from is not None and date < period_from:
+        return False
+    if period_to is not None and date > period_to:
+        return False
+    return True
+
+
+def list_jottings(
+    jot_path: Path,
+    limit: int | None = None,
+    period_from: dt.datetime | None = None,
+    period_to: dt.datetime | None = None,
+) -> None:
     """
     Print the last n jottings from the jot file.
 
     Args:
         jot_path (Path): The path to the jot file.
         limit (int | None): Maximum number of recent jottings to print.
+        period_from (datetime | None): Only match from this date.
+        period_to (datetime | None): Only match until this date.
 
     Returns:
         None: Prints output.
@@ -117,6 +139,9 @@ def list_jottings(jot_path: Path, limit: int | None = None) -> None:
 
     lines = jot_path.read_text(encoding="utf-8").splitlines()
 
+    if period_to is not None or period_from is not None:
+        lines = [line for line in lines if check_in_period(line, period_from, period_to)]
+
     if limit is not None:
         lines = lines[:limit]
 
@@ -124,7 +149,13 @@ def list_jottings(jot_path: Path, limit: int | None = None) -> None:
         console.print(f"{line}")
 
 
-def search_jottings(jot_path: Path, search_term: str, limit: int | None = None) -> None:
+def search_jottings(
+    jot_path: Path,
+    search_term: str,
+    limit: int | None = None,
+    period_from: dt.datetime | None = None,
+    period_to: dt.datetime | None = None,
+) -> None:
     """
     Search for a term in your jottings (regular expressions supported).
 
@@ -132,6 +163,8 @@ def search_jottings(jot_path: Path, search_term: str, limit: int | None = None) 
         jot_path (Path): The path to the jot file.
         search_term (str): Text string to search (regular expressions supported).
         limit (int | None): Maximum number of recent jottings to print.
+        period_from (datetime | None): Only match from this date.
+        period_to (datetime | None): Only match until this date.
 
     Returns:
         None: Prints output.
@@ -143,6 +176,9 @@ def search_jottings(jot_path: Path, search_term: str, limit: int | None = None) 
     with jot_path.open("r", encoding="utf-8") as f:
         lines = [line.rstrip("\n") for line in f]
     matches = [line for line in lines if re.search(search_term, line)]
+
+    if period_to is not None or period_from is not None:
+        matches = [line for line in matches if check_in_period(line, period_from, period_to)]
 
     if limit is not None:
         matches = matches[:limit]


### PR DESCRIPTION
This PR adds basic functionality to list and search between given dates. It uses `dateutil.parser.parse` to parse the command-line arguments. Examples:

```
jot -f 2025-01-01 -t 2025-02-01  # List jottings in January 2025
jot -f 20251001  # List jotttings since the 1st October 2025
jot -t 20250101  # List jottings before 2025
```

Can also be used in conjunction with list and search.