### PR TITLE
Update documentation for date-related flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,19 +27,29 @@ jot "ate an apple"
 
 The first time you run `jot`, you'll be prompted for a path to a text file where your jottings will be written. The file path will be stored under the `JOT_PATH` key in a `jot-config.json` file saved to the location given by pathlib's `Path.home()`.
 
-Each jotting is timestamped and prepended to the text file in the form `[2025-08-25 11:15] ate an apple`.
+Each jotting is timestamped and prepended to your text file:
+
+```
+[2025-08-28 11:15] ate an apple
+[2025-08-27 10:58] ate a kiwi
+[2025-08-26 11:09] ate a pineapple
+[2025-08-25 10:40] ate an apple and a pear
+```
 
 ### Options
 
-You can append optional flags. For example:
+You can review your jottings with optional flags. For example:
 
-* `jot -l 5` to **l**ist the last 5 jottings
-* `jot -s apple` to **s**earch for 'apple' in jottings
-* `jot -s apple -l 3` to **s**earch for 'apple' _and_ **l**imit to 3 jottings
-* `jot -s "2025-08-2([5-9]).*apple"` to **s**earch with regex for 'apple' in a given work week
-* `jot -w` to show **w**here the config and jot files are
-* `jot -v` to get the **v**ersion number
-* `jot -h` to show the **h**elp file
+* `jot -l 3` to <u>l</u>ist the last three
+* `jot -s apple -l 1` to <u>s</u>earch for 'apple' and <u>l</u>imit to the most recent one
+* `jot -s "[^pine]apple"` to <u>s</u>earch for 'apple' with regular expression that excludes 'pineapple'
+* `jot -f 20250825 -t 20250828` to return jottings <u>f</u>rom 25 Aug 2025 (inclusive) and <u>t</u>o 28 Aug 2025 (exclusive)
+
+And for information:
+
+* `jot -w` to show <u>w</u>here the config and jot files are
+* `jot -v` to get the <u>v</u>ersion number
+* `jot -h` to show the <u>h</u>elp file, which includes possible flag combinations
 
 ## Python
 
@@ -54,6 +64,6 @@ search_jottings(jot_path, "apple")
 
 ## Notes
 
-* I developed this to help me remember the tasks I've done during my day job and later reflect.
+* I developed this tool to help me remember the tasks I've done during my day job and later reflect.
 * Your kilometerage may vary; [leave an issue](https://github.com/matt-dray/jot/issues) if you find bugs or have suggestions.
 * [v0.1.0](https://github.com/matt-dray/jot/releases/tag/v0.1.0) developed via LLM, [v0.2.0](https://github.com/matt-dray/jot/compare/v0.1.0...v0.2.0) rewritten with my brain (you can [read about it](https://www.rostrum.blog/posts/2025-08-25-jot/)).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.8.9001"
+version = "0.2.10"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -100,7 +100,9 @@ def create_jot_file() -> Path:
     return jot_path
 
 
-def check_in_period(line: str, period_from: dt.datetime | None, period_to: dt.datetime | None) -> bool:
+def check_in_period(
+    line: str, period_from: dt.datetime | None, period_to: dt.datetime | None
+) -> bool:
     if not line.startswith("[") or "]" not in line:
         return False
     stamp = line[1 : line.index("]")]
@@ -140,7 +142,9 @@ def list_jottings(
     lines = jot_path.read_text(encoding="utf-8").splitlines()
 
     if period_to is not None or period_from is not None:
-        lines = [line for line in lines if check_in_period(line, period_from, period_to)]
+        lines = [
+            line for line in lines if check_in_period(line, period_from, period_to)
+        ]
 
     if limit is not None:
         lines = lines[:limit]
@@ -178,7 +182,9 @@ def search_jottings(
     matches = [line for line in lines if re.search(search_term, line)]
 
     if period_to is not None or period_from is not None:
-        matches = [line for line in matches if check_in_period(line, period_from, period_to)]
+        matches = [
+            line for line in matches if check_in_period(line, period_from, period_to)
+        ]
 
     if limit is not None:
         matches = matches[:limit]


### PR DESCRIPTION
Close #55.

* Updated `README` with an example of `-t` and `-f`, plus other tweaks.
* Reformatted with ruff.
* Bumped version to v0.2.10.