### PR TITLE
Save config to config dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ jot "ate an apple"
 ```
 
 The first time you run `jot`, you'll be prompted for a path to a text file where your jottings will be written.
-The file path will be stored under the `JOT_PATH` key in a `jot-config.json` file saved to the location given by pathlib's `Path.home()`.
+The file path will be stored under the `JOT_PATH` key in a `config.json` file, which is saved to the OS-dependent location resolved by `platformdirs.user_config_path("jot")`.
 
 Each jotting is timestamped and prepended to your text file:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.11.9000"
+version = "0.2.11.9001"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ authors = [
 license = { file = "LICENSE" }
 requires-python = ">=3.10"
 dependencies = [
+    "platformdirs>=4.9.6",
     "python-dateutil>=2.9.0",
     "rich>=14.1.0",
 ]

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -6,6 +6,7 @@ import argparse
 import datetime as dt
 import json
 from pathlib import Path
+from platformdirs import user_config_path
 import re
 
 from rich.console import Console
@@ -15,19 +16,19 @@ console = Console()
 
 
 def get_config_path(
-    config_file: str = ".jot-config.json", home_dir: Path | None = None
+    config_file: str = "config.json", config_dir: Path | None = None
 ) -> Path:
     """
-    Build the path to the config file in the user's home directory.
+    Build the path to the config file in the user's config directory.
 
     Args:
         config_file (str): The file name for the config file.
-        home_dir (Path): The user's home directory.
+        config_dir (Path): The user's config directory.
 
     Returns:
         Path: The file path to the config file.
     """
-    stub = home_dir if home_dir is not None else Path.home()
+    stub = config_dir if config_dir is not None else user_config_path("jot")
     config_path = stub / config_file
     return config_path
 
@@ -60,6 +61,7 @@ def write_to_config(config_path: Path, jot_path: Path) -> None:
     Returns:
         None: Prints output.
     """
+    config_path.parent.mkdir(parents=True, exist_ok=True)
     json_dict = {"JOT_PATH": jot_path.as_posix()}
     with config_path.open("w", encoding="utf-8") as f:
         json.dump(json_dict, f)
@@ -202,18 +204,18 @@ def search_jottings(
         console.print(f"{line}")
 
 
-def print_paths(home_dir: Path | None = None) -> None:
+def print_paths(config_dir: Path | None = None) -> None:
     """
     Print the expected path to the config file and read the jot path from it.
 
     Args:
         config_file (str): The file name for the config file.
-        home_dir (Path): The user's home directory.
+        config_dir (Path): The user's config directory.
 
     Returns:
         None: Prints output.
     """
-    config_path = get_config_path(home_dir=home_dir)
+    config_path = get_config_path(config_dir=config_dir)
     if not config_path.exists():
         console.print(
             f":thinking: Config file not found in expected location: [red]{config_path}[/]"

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -11,7 +11,7 @@ import jot.core as core
 def test_get_config_path(tmp_path: Path):
     path = core.get_config_path(
         config_file="config.json",
-        home_dir=tmp_path,
+        config_dir=tmp_path,
     )
     assert path == tmp_path / "config.json"
 
@@ -105,7 +105,7 @@ def test_search_jottings(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
 
 
 def test_print_paths_missing_config(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
-    core.print_paths(home_dir=tmp_path)
+    core.print_paths(config_dir=tmp_path)
 
     out = capsys.readouterr().out
     assert "Config file not found" in out

--- a/uv.lock
+++ b/uv.lock
@@ -37,6 +37,7 @@ name = "jot"
 version = "0.2.11.9000"
 source = { editable = "." }
 dependencies = [
+    { name = "platformdirs" },
     { name = "python-dateutil" },
     { name = "rich" },
 ]
@@ -48,6 +49,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "platformdirs", specifier = ">=4.9.6" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2" },
     { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "rich", specifier = ">=14.1.0" },
@@ -82,6 +84,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "platformdirs"
+version = "4.9.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4a/0883b8e3802965322523f0b200ecf33d31f10991d0401162f4b23c698b42/platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a", size = 29400, upload-time = "2026-04-09T00:04:10.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/a6/a0a304dc33b49145b21f4808d763822111e67d1c3a32b524a1baf947b6e1/platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917", size = 21348, upload-time = "2026-04-09T00:04:09.463Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Close #14.

* Updated to save config file by default to OS-dependent config directory.
* Added platformdirs as a dependency.
* Updated README to note where config is saved by default.
* Updated tests as a result of this change.