### PR TITLE
Shorten confirmation message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.11.9001"
+version = "0.2.11.9002"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/core.py
+++ b/src/jot/core.py
@@ -87,12 +87,12 @@ def write_jotting(
     if jot_path.exists():
         jot_file_content = jot_path.read_text(encoding="utf-8")
 
-    timestamp = now_dt().strftime("[%Y-%m-%d %H:%M]")
+    timestamp = now_dt().strftime("%Y-%m-%d %H:%M")
     jot_path.write_text(
-        f"{timestamp} {args.text}\n{jot_file_content}",
+        f"[{timestamp}] {args.text}\n{jot_file_content}",
         encoding="utf-8",
     )
-    console.print(f':memo: Wrote [green]"{args.text}"[/green] to [green]{jot_path}[/]')
+    console.print(f":white_check_mark: Jotted at {timestamp}")
 
 
 def create_jot_file(prompt_user=Prompt.ask) -> Path:

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.11.9001"
+version = "0.2.11.9002"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
Close #60.

* Shortened the printed message when a jotting is written successfully: `✅ Jotted at YYYY-MM-DD HH:MM`.
* ~~Recognised @francisbarton in `CONTRIBUTORS.md`.~~ Actually in #67.