### PR TITLE
Write arbitrary key-value pairs to config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.11.9004"
+version = "0.2.11.9005"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -96,7 +96,7 @@ def main() -> None:
         jot_path = read_jot_path(config_path)
     else:
         jot_path = create_jot_file()
-        write_to_config(config_path, jot_path)
+        write_to_config(config_path, "JOT_PATH", jot_path.as_posix())
 
     if args.where:
         print_paths()

--- a/src/jot/files.py
+++ b/src/jot/files.py
@@ -49,23 +49,47 @@ def read_jot_path(config_path: Path) -> Path:
     return jot_path
 
 
-def write_to_config(config_path: Path, jot_path: Path) -> None:
+def write_to_config(
+    config_path: Path, key: str, value: str, prompt_user=Prompt.ask
+) -> None:
     """
-    Write the jot file path to the config file.
+    Write a key-value pair to the config file.
+
+    Any key-value is accepted, but JOT_PATH is required and GIST_ID is optional.
 
     Args:
         config_path (Path): The path to the config file.
-        jot_path (Path): The path to the jot file.
+        key (str): The JSON key to be written to the config file.
+        value (ste): The value for the JSON key to be written to the config file.
+        prompt_user (Prompt.ask): Prompt the user for input.
 
     Returns:
-        None: Prints output.
+        None: Writes to file and prints output.
     """
+    if config_path.exists():
+        with config_path.open("r", encoding="utf-8") as f:
+            config = json.load(f)
+    else:
+        config = {}
+
+    if key in config:
+        overwrite = prompt_user(
+            f":exclamation: [green]{key}[/] is already set to [green]{config[key]}[/]. Overwrite?",
+            choices=["y", "n"],
+        )
+        if overwrite == "n":
+            console.print(
+                f":x: [green]{key}[/] will not be overwritten in the config file. Exiting."
+            )
+            return
+
+    config[key] = value
+
     config_path.parent.mkdir(parents=True, exist_ok=True)
-    json_dict = {"JOT_PATH": jot_path.as_posix()}
     with config_path.open("w", encoding="utf-8") as f:
-        json.dump(json_dict, f)
-    console.print(f":white_check_mark: Created config file at [green]{config_path}[/]")
-    console.print(f":white_check_mark: Set JOT_PATH variable to [green]{jot_path}[/]")
+        json.dump(config, f)
+
+    console.print(f":white_check_mark: Set [green]{key}[/] to [green]{value}[/]")
 
 
 def write_jotting(

--- a/src/jot/files.py
+++ b/src/jot/files.py
@@ -55,7 +55,7 @@ def write_to_config(
     """
     Write a key-value pair to the config file.
 
-    Any key-value is accepted, but JOT_PATH is required and GIST_ID is optional.
+    Any key-value is accepted, but JOT_PATH is required by jot and GIST_ID is optional.
 
     Args:
         config_path (Path): The path to the config file.

--- a/src/jot/files.py
+++ b/src/jot/files.py
@@ -142,8 +142,11 @@ def create_jot_file(prompt_user=Prompt.ask) -> Path:
         jot_path = Path(jot_path_str).expanduser().resolve()
 
         if jot_path.exists():
-            confirm = prompt_user(":exclamation: File already exists. Use it? y/n")
-            if confirm.lower() != "y":
+            confirm = prompt_user(
+                ":exclamation: File already exists. Use it?",
+                choices=["y", "n"],
+            )
+            if confirm.lower() == "n":
                 continue
         else:
             jot_path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -21,7 +21,7 @@ def test_write_and_read_config(tmp_path: Path):
     config = tmp_path / "config.json"
     jot = tmp_path / "jot.txt"
 
-    files.write_to_config(config, jot)
+    files.write_to_config(config, "JOT_PATH", jot.as_posix())
 
     data = json.loads(config.read_text())
     assert data["JOT_PATH"] == jot.as_posix()

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.11.9003"
+version = "0.2.11.9005"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
Close #75, preparing for #3.

* Added `key` and `value` arguments to `write_to_config()`.
* Used `choices` when asking the user for input re a pre-existing jot path.
* Updated config-writing test.
* Bumped the dev version.