### PR TITLE
Use a more generic config-reading function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "jot"
-version = "0.2.11.9005"
+version = "0.2.11.9006"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
 authors = [

--- a/src/jot/__init__.py
+++ b/src/jot/__init__.py
@@ -5,7 +5,7 @@ Minimal opinionated Python CLI to jot timestamped thoughts.
 from .files import (
     create_jot_file,
     get_config_path,
-    read_jot_path,
+    read_config,
     write_to_config,
     write_jotting,
 )
@@ -23,7 +23,7 @@ __all__ = [
     "get_config_path",
     "list_jottings",
     "print_paths",
-    "read_jot_path",
+    "read_config",
     "search_jottings",
     "write_to_config",
     "write_jotting",

--- a/src/jot/cli.py
+++ b/src/jot/cli.py
@@ -5,11 +5,12 @@ CLI entry with argument parser.
 import argparse
 from dateutil.parser import parse as date_time
 from importlib.metadata import version
+from pathlib import Path
 
 from .files import (
     create_jot_file,
     get_config_path,
-    read_jot_path,
+    read_config,
     write_to_config,
     write_jotting,
 )
@@ -93,7 +94,8 @@ def main() -> None:
     config_path = get_config_path()
 
     if config_path.exists():
-        jot_path = read_jot_path(config_path)
+        jot_path = read_config(config_path, "JOT_PATH")
+        jot_path = Path(jot_path)
     else:
         jot_path = create_jot_file()
         write_to_config(config_path, "JOT_PATH", jot_path.as_posix())

--- a/src/jot/files.py
+++ b/src/jot/files.py
@@ -32,21 +32,23 @@ def get_config_path(
     return config_path
 
 
-def read_jot_path(config_path: Path) -> Path:
+def read_config(config_path: Path, key: str) -> str:
     """
-    Read the jot file path from the config file.
+    Read the value from a key in the config file.
 
     Args:
         config_path (Path): The path to the config file.
+        key (str): The key to read. Could be JOT_PATH or GIST_ID.
 
     Returns:
-        Path: The file path to the jot file.
+         str: Value for the config key, or None if not found.
     """
     config_text = config_path.read_text(encoding="utf-8")
     config_json = json.loads(config_text)
-    jot_path_text = config_json["JOT_PATH"]
-    jot_path = Path(jot_path_text)
-    return jot_path
+    value = config_json.get(key)
+    if value is None:
+        raise KeyError(f"{key} not found in config.")
+    return value
 
 
 def write_to_config(
@@ -158,7 +160,7 @@ def create_jot_file(prompt_user=Prompt.ask) -> Path:
 __all__ = [
     "create_jot_file",
     "get_config_path",
-    "read_jot_path",
+    "read_config",
     "write_to_config",
     "write_jotting",
 ]

--- a/src/jot/options.py
+++ b/src/jot/options.py
@@ -8,7 +8,7 @@ import re
 
 from .files import (
     get_config_path,
-    read_jot_path,
+    read_config,
 )
 
 from rich.console import Console
@@ -88,13 +88,13 @@ def print_paths(config_dir: Path | None = None) -> None:
     Print the expected path to the config file and read the jot path from it.
 
     Args:
-        config_file (str): The file name for the config file.
         config_dir (Path): The user's config directory.
 
     Returns:
         None: Prints output.
     """
     config_path = get_config_path(config_dir=config_dir)
+
     if not config_path.exists():
         console.print(
             f":x: Couldn't find the config file in the expected location: [red]{config_path}[/]"
@@ -103,7 +103,9 @@ def print_paths(config_dir: Path | None = None) -> None:
 
     console.print(f":round_pushpin: Config file: [green]{config_path}[/]")
 
-    jot_path = read_jot_path(config_path)
+    jot_path = read_config(config_path, "JOT_PATH")
+    jot_path = Path(jot_path)
+
     if not jot_path.exists():
         console.print(
             f":x: Couldn't find the jot file in the expected location: [red]{jot_path}[/]"

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,51 @@
+import argparse
+import datetime as dt
+import json
+from pathlib import Path
+
+import jot.files as files
+
+
+def test_get_config_path(tmp_path: Path):
+    path = files.get_config_path(
+        config_file="config.json",
+        config_dir=tmp_path,
+    )
+    assert path == tmp_path / "config.json"
+
+
+def test_write_and_read_config(tmp_path: Path):
+    config = tmp_path / "config.json"
+    jot = tmp_path / "jot.txt"
+
+    files.write_to_config(config, "JOT_PATH", jot.as_posix())
+
+    data = json.loads(config.read_text())
+    assert data["JOT_PATH"] == jot.as_posix()
+    assert Path(files.read_config(config, "JOT_PATH")) == jot
+
+
+def test_write_jotting_prepends(tmp_path: Path):
+    def fixed_now():
+        return dt.datetime(2025, 12, 25, 1, 0)
+
+    jot = tmp_path / "jot.txt"
+    jot.write_text("[2025-12-24 23:00] egg\n")
+
+    args = argparse.Namespace(text="spam")
+
+    files.write_jotting(jot, args, now_dt=fixed_now)
+
+    content = jot.read_text()
+    assert content.startswith("[2025-12-25 01:00] spam")
+    assert "egg" in content
+
+
+def test_create_jot_file(tmp_path: Path):
+    def prompt(_):
+        return str(tmp_path / "spam.txt")
+
+    jot = files.create_jot_file(prompt_user=prompt)
+
+    assert jot.exists()
+    assert jot.name == "spam.txt"

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,65 +1,9 @@
-import argparse
 import datetime as dt
-import json
 from pathlib import Path
 
 import pytest
 
-import jot.files as files
 import jot.options as options
-
-
-def test_get_config_path(tmp_path: Path):
-    path = files.get_config_path(
-        config_file="config.json",
-        config_dir=tmp_path,
-    )
-    assert path == tmp_path / "config.json"
-
-
-def test_write_and_read_config(tmp_path: Path):
-    config = tmp_path / "config.json"
-    jot = tmp_path / "jot.txt"
-
-    files.write_to_config(config, "JOT_PATH", jot.as_posix())
-
-    data = json.loads(config.read_text())
-    assert data["JOT_PATH"] == jot.as_posix()
-    assert files.read_jot_path(config) == jot
-
-
-def test_write_jotting_prepends(tmp_path: Path):
-    def fixed_now():
-        return dt.datetime(2025, 12, 25, 1, 0)
-
-    jot = tmp_path / "jot.txt"
-    jot.write_text("[2025-12-24 23:00] egg\n")
-
-    args = argparse.Namespace(text="spam")
-
-    files.write_jotting(jot, args, now_dt=fixed_now)
-
-    content = jot.read_text()
-    assert content.startswith("[2025-12-25 01:00] spam")
-    assert "egg" in content
-
-
-def test_create_jot_file(tmp_path: Path):
-    def prompt(_):
-        return str(tmp_path / "spam.txt")
-
-    jot = files.create_jot_file(prompt_user=prompt)
-
-    assert jot.exists()
-    assert jot.name == "spam.txt"
-
-
-def test_check_in_period_valid():
-    line = "[2025-12-25 09:00] spam"
-    start = dt.datetime(2025, 12, 1)
-    end = dt.datetime(2025, 12, 31)
-
-    assert options.check_in_period(line, start, end)
 
 
 @pytest.mark.parametrize(
@@ -103,6 +47,14 @@ def test_search_jottings(tmp_path: Path, capsys: pytest.CaptureFixture[str]):
     out = capsys.readouterr().out
     assert "egg" in out
     assert "lobster" not in out
+
+
+def test_check_in_period_valid():
+    line = "[2025-12-25 09:00] spam"
+    start = dt.datetime(2025, 12, 1)
+    end = dt.datetime(2025, 12, 31)
+
+    assert options.check_in_period(line, start, end)
 
 
 def test_print_paths_missing_config(tmp_path: Path, capsys: pytest.CaptureFixture[str]):

--- a/uv.lock
+++ b/uv.lock
@@ -34,7 +34,7 @@ wheels = [
 
 [[package]]
 name = "jot"
-version = "0.2.11.9005"
+version = "0.2.11.9006"
 source = { editable = "." }
 dependencies = [
     { name = "platformdirs" },


### PR DESCRIPTION
Towards #3, following https://github.com/matt-dray/jot/issues/3#issuecomment-4558026089.

* Replace `read_jot_path()` function with more arbitrary `read_config()`.
* Update uses of `read_jot_path()` throughout scripts and test files.
* Split test files so they correspond to `files.py` and `options.py`.
* Bumped dev version.