### PR TITLE
Rename project to jot-cli in pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "jot"
+name = "jot-cli"
 version = "0.3.0"
 description = "Minimal opinionated Python CLI to jot timestamped thoughts."
 readme = "README.md"
@@ -34,3 +34,6 @@ dev = [
 [build-system]
 requires = ["uv_build>=0.11.11,<0.12"]
 build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = "jot"


### PR DESCRIPTION
PyPi already has 'jot', so this project should be named something else. 'jot-cli' is available.